### PR TITLE
banned paths

### DIFF
--- a/files.php
+++ b/files.php
@@ -31,8 +31,26 @@ class SortingIterator implements IteratorAggregate {
 	}
 }
 
+class IgnorantRecursiveDirectoryIterator extends RecursiveDirectoryIterator {
+  function getChildren() {
+    try {
+//      echo "<pre>".var_export( $this->key(), true )."</pre>";
+//      echo "<pre>".var_export( $this->getSubPath(), true )."</pre>";
+//      echo "<pre>".var_export( $this->getSubPathname(), true )."</pre>";
+      if ( (!isset($GLOBALS['ICEcoder']['bannedPaths'])) || 
+           (! (in_array( $this->key(), $GLOBALS['ICEcoder']['bannedPaths'] ))) ) {
+             return parent::getChildren();
+	} else {
+          return new RecursiveArrayIterator(array());
+	}
+    } catch(UnexpectedValueException $e) {
+      return new RecursiveArrayIterator(array());
+    }
+  }
+}
+
 // Get a full list of dirs & files and begin sorting using above class & function
-$objectList = new SortingIterator(new RecursiveIteratorIterator(new RecursiveDirectoryIterator($docRoot.$iceRoot), RecursiveIteratorIterator::SELF_FIRST), 'alphasort');
+$objectList = new SortingIterator(new RecursiveIteratorIterator(new IgnorantRecursiveDirectoryIterator($docRoot.$iceRoot), RecursiveIteratorIterator::SELF_FIRST), 'alphasort');
 
 // With that done, create arrays for out final ordered list and a temp container of files
 $finalArray = $tempArray =  array();

--- a/lib/config.php
+++ b/lib/config.php
@@ -10,6 +10,7 @@ $ICEcoder = array(
 "lockedNav"		=> true,
 "accountPassword"	=> "",
 "bannedFiles"		=> array("_coder","ICEcoder"),
+"bannedPaths"		=> array("/var/www/.git","/var/www/sites/all/modules","/var/www/sites/default/files"),
 "allowedIPs"		=> array("*"),
 "plugins"		=> array(
 			array("Adminer","plugins/adminer/icon.png","margin-top: 3px","plugins/adminer/adminer-3.4.0-mysql-en.php","_blank",""),


### PR DESCRIPTION
The SortingIterator chokes on my Drupal sites/all/modules directory.    This doesn't happen with all drupal site modules directories,  just mine.   I haven't figured out which module is causing the issue yet.  I omit the entire subdir in order to get the sorted tree for the rest of the site at least.   The ban happens before it's sorted,  unlike the other ban which filters after everything is recursed over.
