### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can run ICEcoder either online or locally, on Linux, Windows or Mac based pl
 Either download the zip or clone from Github using:
 
 ```
-$ git clone git@github.com:mattpass/ICEcoder
+$ git clone git://github.com/mattpass/ICEcoder
 ```
 
 ####Step 2: Place in your document root (online or local)


### PR DESCRIPTION
the git clone address needed a public key and is only needed to gain write acces to ICEcoder.

replaced with a read-only alternate github address
