### PR TITLE
Fix for #791

### DIFF
--- a/lib/settings-common.php
+++ b/lib/settings-common.php
@@ -164,7 +164,7 @@ define('SALT_LENGTH',12);
 // Generate hash
 function generateHash($pw) {
     // Generate Bcrypt hash
-    return str_replace("\$", "\\$", password_hash($pw, PASSWORD_BCRYPT, $options = ['cost' => 10]));
+    return password_hash($pw, PASSWORD_BCRYPT, $options = ['cost' => 10]);
 }
 
 // Verify hash

--- a/lib/settings-update.php
+++ b/lib/settings-update.php
@@ -56,7 +56,12 @@ if (!$demoMode && isset($_SESSION['loggedIn']) && $_SESSION['loggedIn'] && isset
 		$settingsNew .= '"'.$settingsArray[$i].'"	=> ';
 		// Wrap certain values in double quotes
 		$settingWrap = $settingsArray[$i]=="root"||$settingsArray[$i]=="password"||$settingsArray[$i]=="languageUser"||$settingsArray[$i]=="theme"||$settingsArray[$i]=="fontSize"||$settingsArray[$i]=="tagWrapperCommand"||$settingsArray[$i]=="autoComplete"||$settingsArray[$i]=="pluginPanelAligned"||$settingsArray[$i]=="githubAuthToken" ? '"' : '';
-		$settingsNew .= $settingWrap.$ICEcoder[$settingsArray[$i]].$settingWrap.','.PHP_EOL;
+		
+		if ($settingsArray[$i]=="password") {
+			$settingsNew .= str_replace("\$", "\\$", $settingWrap.$ICEcoder[$settingsArray[$i]].$settingWrap.','.PHP_EOL);
+		} else {
+			$settingsNew .= $settingWrap.$ICEcoder[$settingsArray[$i]].$settingWrap.','.PHP_EOL;
+		}
 	}
 
 	// Compile our new settings


### PR DESCRIPTION
When you hit the "Update" button in the settings menu for any reason, no matter 
if you change anything or not, the password field in the user config file is updated and the 
slashes"\" are stripped and PHP can't properly read the hashed password without 
the dollar signs escaped.